### PR TITLE
refactor(terraform): updates database and ecs configurations to test …

### DIFF
--- a/_tf/modules/containers/containers.tf
+++ b/_tf/modules/containers/containers.tf
@@ -68,8 +68,8 @@ resource "aws_ecs_task_definition" "front" {
     image        = "${aws_ecr_repository.front.repository_url}@${data.aws_ecr_image.front.image_digest}",
     essential    = true,
     network_mode = "awsvpc",
-    memory       = 1024,
-    cpu          = 512,
+    memory       = 512,
+    cpu          = 256,
     portMappings = [
       {
         containerPort = 3000,
@@ -97,8 +97,8 @@ resource "aws_ecs_task_definition" "front" {
   }])
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  memory                   = 2048
-  cpu                      = 1024
+  memory                   = 512
+  cpu                      = 256
   execution_role_arn       = aws_iam_role.this.arn
 }
 
@@ -135,8 +135,8 @@ resource "aws_ecs_task_definition" "strapi" {
     image        = "${aws_ecr_repository.strapi.repository_url}@${data.aws_ecr_image.strapi.image_digest}",
     essential    = true,
     network_mode = "awsvpc",
-    memory       = 1024,
-    cpu          = 512,
+    memory       = 512,
+    cpu          = 256,
     portMappings = [
       {
         containerPort = 1337,
@@ -164,8 +164,8 @@ resource "aws_ecs_task_definition" "strapi" {
   }])
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  memory                   = 2048
-  cpu                      = 1024
+  memory                   = 512
+  cpu                      = 256
   execution_role_arn       = aws_iam_role.this.arn
 }
 

--- a/_tf/modules/database/database.tf
+++ b/_tf/modules/database/database.tf
@@ -2,19 +2,23 @@
 # CMS Database
 # ------------------------------------------------------------------------------
 resource "aws_db_instance" "this" {
-  depends_on             = [var.service_sg]
-  identifier             = var.dashed_cmsdomain
-  allocated_storage      = 10
-  engine                 = "postgres"
-  engine_version         = "10.23"
-  instance_class         = "db.t2.small"
-  db_name                = "strapi"
-  username               = "strapi"
-  password               = var.db_password
-  vpc_security_group_ids = ["${var.service_sg.id}"]
-  db_subnet_group_name   = var.db_subnet_group.id
-  skip_final_snapshot    = "true"
+  depends_on                = [var.service_sg]
+  identifier                = var.dashed_cmsdomain
+  allocated_storage         = 10
+  engine                    = "postgres"
+  engine_version            = "10.23"
+  instance_class            = var.instance_class
+  db_name                   = "strapi"
+  username                  = "strapi"
+  password                  = var.db_password
+  vpc_security_group_ids    = ["${var.service_sg.id}"]
+  db_subnet_group_name      = var.db_subnet_group.id
+  skip_final_snapshot       = var.skip_final_snapshot
+  final_snapshot_identifier = var.dashed_cmsdomain
+  apply_immediately         = true
+  backup_retention_period   = 3
+  backup_window             = "06:00-07:00"
   lifecycle {
-    prevent_destroy = false
+    prevent_destroy = true
   }
 }

--- a/_tf/modules/database/inputs.tf
+++ b/_tf/modules/database/inputs.tf
@@ -1,6 +1,8 @@
 variable "dashed_cmsdomain" {}
 variable "service_sg" {}
 variable "db_subnet_group" {}
+variable "instance_class" {}
+variable "skip_final_snapshot" {}
 variable "db_password" {
   sensitive = true
 }

--- a/_tf/stg/main.tf
+++ b/_tf/stg/main.tf
@@ -37,11 +37,13 @@ module "containers" {
 }
 
 module "database" {
-  source           = "../modules/database"
-  service_sg       = module.security.service_sg
-  db_subnet_group  = module.network.db_subnet_group
-  dashed_cmsdomain = local.dashed_cmsdomain
-  db_password      = var.db_password
+  source              = "../modules/database"
+  service_sg          = module.security.service_sg
+  db_subnet_group     = module.network.db_subnet_group
+  dashed_cmsdomain    = local.dashed_cmsdomain
+  db_password         = var.db_password
+  instance_class      = "db.t2.micro"
+  skip_final_snapshot = true
 }
 
 module "management" {


### PR DESCRIPTION
…cost savings

reduced the cpu and memory on ecs tasks, and also reduced the rds instance to db.t2.micro and set it by variable so prod and stg can have different configs

┆Issue is synchronized with this [Trello card](https://trello.com/c/GHC924Rs) by [Unito](https://www.unito.io)
