### PR TITLE
Release/2.4.0

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -4,6 +4,12 @@
     "version": "2.3.1",
     "tag_format": "$major.$minor.$patch$prerelease",
     "version_type": "semver",
-    "bump_message": "release $current_version \u2192 $new_version"
+    "bump_message": "release $current_version \u2192 $new_version",
+    "version_files": [
+      "back/package.json",
+      "back/package-lock.json",
+      "front/package.json",
+      "front/package-lock.json"
+    ]
   }
 }

--- a/.cz.json
+++ b/.cz.json
@@ -1,7 +1,7 @@
 {
   "commitizen": {
     "name": "cz_conventional_commits",
-    "version": "2.3.1",
+    "version": "2.4.0",
     "tag_format": "$major.$minor.$patch$prerelease",
     "version_type": "semver",
     "bump_message": "release $current_version \u2192 $new_version",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.4.0] - 2023-06-28
+
+### 💡 Features
+
+- ***(docker)*** Adds patch-package step and improves caching
+- ***(strapi)*** Upgrades strapi to v4.11.3
+- ***(strapi)*** Adds plausible analytics dashboard to strapi
+
+### 🐛 Bug Fixes
+
+- ***(front)*** Adjusts padding for `p`s and `h*`s
+
+### 👷 Build
+
+- ***(project)*** Updates and includes package files in cz bump
+- ***(strapi)*** Upgrades patches for strapi 4.11.3
+- ***(strapi)*** Uninstalls postinstall-postinstall
+
 ## [2.3.1] - 2023-06-27
 
 ### 🐛 Bug Fixes

--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cms.dgrebb.com",
-  "version": "1.0.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cms.dgrebb.com",
-      "version": "1.0.0",
+      "version": "2.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cms.dgrebb.com",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cms.dgrebb.com",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2576,8 +2576,8 @@
       "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.1.tgz",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.4.0.tgz",
       "integrity": "sha512-knF2AkAKN4Upv4oIiKY4Wd/dLH68TNMPgV/tJMu/T6FP9aQwbv8fpj7U3lkyniPaNVxvia56Gxax8MKOjtxLSQ==",
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.14.3",
@@ -2611,7 +2611,7 @@
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.14.3",
         "@formatjs/fast-memoize": "2.0.1",
-        "@formatjs/icu-messageformat-parser": "2.3.1",
+        "@formatjs/icu-messageformat-parser": "2.4.0",
         "@formatjs/intl-displaynames": "6.3.1",
         "@formatjs/intl-listformat": "7.2.1",
         "intl-messageformat": "10.3.4",
@@ -8921,7 +8921,7 @@
       "dependencies": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
+        "braces": "^2.4.0",
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
         "extglob": "^2.0.4",
@@ -10261,7 +10261,7 @@
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.14.3",
         "@formatjs/fast-memoize": "2.0.1",
-        "@formatjs/icu-messageformat-parser": "2.3.1",
+        "@formatjs/icu-messageformat-parser": "2.4.0",
         "tslib": "^2.4.0"
       }
     },
@@ -10772,8 +10772,8 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.4.0.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-schema-traverse": {
@@ -11394,7 +11394,7 @@
         "@types/triple-beam": "^1.3.2",
         "fecha": "^4.2.0",
         "ms": "^2.1.1",
-        "safe-stable-stringify": "^2.3.1",
+        "safe-stable-stringify": "^2.4.0",
         "triple-beam": "^1.3.0"
       }
     },
@@ -11674,7 +11674,7 @@
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dependencies": {
         "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
+        "picomatch": "^2.4.0"
       },
       "engines": {
         "node": ">=8.6"
@@ -12930,8 +12930,8 @@
       }
     },
     "node_modules/patch-package/node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.0.tgz",
       "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
       "dev": true,
       "engines": {
@@ -13106,8 +13106,8 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.4.0.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
@@ -14021,7 +14021,7 @@
       "integrity": "sha512-/aT5595AEMZ+Pjmt8W2R5/ZkYJmyyd6jTzHzqhJ1LnfeG36+N5huBtykxYhHqLc1BrIRQ1fTX1orYC0Ej5ojtg==",
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/icu-messageformat-parser": "2.3.1",
+        "@formatjs/icu-messageformat-parser": "2.4.0",
         "@formatjs/intl": "2.7.1",
         "@formatjs/intl-displaynames": "6.3.1",
         "@formatjs/intl-listformat": "7.2.1",
@@ -17171,7 +17171,7 @@
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
+        "json-parse-even-better-errors": "^2.4.0",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",

--- a/back/package.json
+++ b/back/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cms.dgrebb.com",
   "private": true,
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "cms.dgrebb.com",
   "scripts": {
     "develop": "strapi develop",

--- a/back/package.json
+++ b/back/package.json
@@ -1,8 +1,8 @@
 {
   "name": "cms.dgrebb.com",
   "private": true,
-  "version": "1.0.0",
-  "description": "dgrebb.com CMS",
+  "version": "2.3.1",
+  "description": "cms.dgrebb.com",
   "scripts": {
     "develop": "strapi develop",
     "start": "strapi start",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dgrebb.com",
-	"version": "2.3.1",
+	"version": "2.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dgrebb.com",
-			"version": "2.3.1",
+			"version": "2.4.0",
 			"dependencies": {
 				"@accuser/svelte-plausible-analytics": "github:dgrebb/svelte-plausible-analytics#release/v0.4.0",
 				"@sentry/sveltekit": "^7.56.0",
@@ -2003,7 +2003,7 @@
 			"dev": true,
 			"dependencies": {
 				"braces": "^3.0.2",
-				"picomatch": "^2.3.1"
+				"picomatch": "^2.4.0"
 			},
 			"engines": {
 				"node": ">=8.6"
@@ -2325,8 +2325,8 @@
 			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.4.0.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"engines": {
 				"node": ">=8.6"
@@ -3318,8 +3318,8 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
 		},
 		"node_modules/yaml": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.0.tgz",
 			"integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
 			"dev": true,
 			"engines": {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "svelte",
-	"version": "0.0.1",
+	"name": "dgrebb.com",
+	"version": "2.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "svelte",
-			"version": "0.0.1",
+			"name": "dgrebb.com",
+			"version": "2.3.1",
 			"dependencies": {
 				"@accuser/svelte-plausible-analytics": "github:dgrebb/svelte-plausible-analytics#release/v0.4.0",
 				"@sentry/sveltekit": "^7.56.0",

--- a/front/package.json
+++ b/front/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dgrebb.com",
-	"version": "2.3.1",
+	"version": "2.4.0",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",

--- a/front/package.json
+++ b/front/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "svelte",
-	"version": "0.0.1",
+	"name": "dgrebb.com",
+	"version": "2.3.1",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
### 💡 Features

- ***(docker)*** Adds patch-package step and improves caching
- ***(strapi)*** Upgrades strapi to v4.11.3
- ***(strapi)*** Adds plausible analytics dashboard to strapi

### 🐛 Bug Fixes

- ***(front)*** Adjusts padding for `p`s and `h*`s

### 👷 Build

- ***(project)*** Updates and includes package files in cz bump
- ***(strapi)*** Upgrades patches for strapi 4.11.3
- ***(strapi)*** Uninstalls postinstall-postinstall