### PR TITLE
Feature/cms post fields and components

### DIFF
--- a/back/src/api/category/content-types/category/schema.json
+++ b/back/src/api/category/content-types/category/schema.json
@@ -1,0 +1,19 @@
+{
+  "kind": "collectionType",
+  "collectionName": "categories",
+  "info": {
+    "singularName": "category",
+    "pluralName": "categories",
+    "displayName": "Category",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string"
+    }
+  }
+}

--- a/back/src/api/category/controllers/category.js
+++ b/back/src/api/category/controllers/category.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * category controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::category.category');

--- a/back/src/api/category/routes/category.js
+++ b/back/src/api/category/routes/category.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * category router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::category.category');

--- a/back/src/api/category/services/category.js
+++ b/back/src/api/category/services/category.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * category service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::category.category');

--- a/back/src/api/post/content-types/post/schema.json
+++ b/back/src/api/post/content-types/post/schema.json
@@ -4,7 +4,8 @@
   "info": {
     "singularName": "post",
     "pluralName": "posts",
-    "displayName": "Post"
+    "displayName": "Post",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true
@@ -20,6 +21,38 @@
       "type": "uid",
       "targetField": "title",
       "required": true
+    },
+    "content": {
+      "type": "dynamiczone",
+      "components": [
+        "posts.text",
+        "posts.image-carousel",
+        "posts.code",
+        "posts.html"
+      ]
+    },
+    "related": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::post.post"
+    },
+    "categories": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::category.category"
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.seo"
+    },
+    "hero": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images"
+      ]
     }
   }
 }

--- a/back/src/api/post/controllers/post.js
+++ b/back/src/api/post/controllers/post.js
@@ -1,19 +1,24 @@
 "use strict";
 
-/**
- * post controller
- */
-
+const { sanitize } = require('@strapi/utils');
 const { createCoreController } = require("@strapi/strapi").factories;
 
 module.exports = createCoreController("api::post.post", ({ strapi }) => ({
-  async findOne(ctx) {
-    const { slug } = ctx.params;
-    const entity = await strapi.db.query("api::post.post").findOne({
-      where: { slug },
-    });
-    const sanitizedEntity = await this.sanitizeOutput(entity);
+  async findBySlug(ctx) {
+    try {
+      const { slug } = ctx.params;
+      const query = {
+        filters: { slug },
+        ...ctx.query,
+      };
 
-    return this.transformResponse(sanitizedEntity);
+      const post = await strapi.entityService.findMany("api::post.post", query);
+      const schema = strapi.getModel("api::post.post");
+      const sanitizedEntity = await sanitize.contentAPI.output(post, schema);
+
+      return this.transformResponse(sanitizedEntity[0]);
+    } catch (error) {
+      ctx.body = error;
+    }
   },
 }));

--- a/back/src/api/post/controllers/post.js
+++ b/back/src/api/post/controllers/post.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { sanitize } = require('@strapi/utils');
+const { sanitize } = require("@strapi/utils");
 const { createCoreController } = require("@strapi/strapi").factories;
 
 module.exports = createCoreController("api::post.post", ({ strapi }) => ({

--- a/back/src/api/post/routes/slug.js
+++ b/back/src/api/post/routes/slug.js
@@ -3,10 +3,10 @@ module.exports = {
     {
       method: "GET",
       path: "/post/:slug",
-      handler: 'post.findOne',
+      handler: "post.findBySlug",
       config: {
         auth: false,
-      }
+      },
     },
   ],
 };

--- a/back/src/components/posts/code.json
+++ b/back/src/components/posts/code.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_posts_codes",
+  "info": {
+    "displayName": "Code",
+    "icon": "code"
+  },
+  "options": {},
+  "attributes": {
+    "language": {
+      "type": "string"
+    },
+    "code": {
+      "type": "text"
+    },
+    "title": {
+      "type": "string"
+    }
+  }
+}

--- a/back/src/components/posts/html.json
+++ b/back/src/components/posts/html.json
@@ -1,0 +1,13 @@
+{
+  "collectionName": "components_posts_htmls",
+  "info": {
+    "displayName": "HTML",
+    "icon": "paint"
+  },
+  "options": {},
+  "attributes": {
+    "html": {
+      "type": "text"
+    }
+  }
+}

--- a/back/src/components/posts/image-carousel.json
+++ b/back/src/components/posts/image-carousel.json
@@ -1,0 +1,26 @@
+{
+  "collectionName": "components_posts_image_carousels",
+  "info": {
+    "displayName": "Image Carousel",
+    "icon": "landscape"
+  },
+  "options": {},
+  "attributes": {
+    "images": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": true
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "richtext"
+    }
+  }
+}

--- a/back/src/components/posts/text.json
+++ b/back/src/components/posts/text.json
@@ -1,0 +1,13 @@
+{
+  "collectionName": "components_posts_texts",
+  "info": {
+    "displayName": "Text",
+    "icon": "pencil"
+  },
+  "options": {},
+  "attributes": {
+    "text": {
+      "type": "richtext"
+    }
+  }
+}


### PR DESCRIPTION
Adds all Post fields, content components, seo, relations (categories, related posts), field layout and labels, and custom api controller for `findBySlug` with `?populate` query support.

- closes #383 
- closes #382 
- closes #371 
- closes #372 
- closes #281 
- closes #374