### PR TITLE
chore(ci): adjusts bump.sh to only apply file changes, not tag

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -4,6 +4,7 @@
     "version": "3.0.2",
     "tag_format": "$major.$minor.$patch$prerelease",
     "version_type": "semver",
+    "version_files": ["back/package.json", "front/package.json"],
     "bump_message": "release $current_version \u2192 $new_version",
     "customize": {
       "info": "This is customized info",

--- a/_utils/_scripts/bump.sh
+++ b/_utils/_scripts/bump.sh
@@ -37,13 +37,13 @@ echo # newline
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     exit 1
 fi
-cdfront
-npm version $ver
-cdback
-npm version $ver
+# cdfront
+# npm version $ver
+# cdback
+# npm version $ver
 cd $directory/../
 git add .
-cz bump
+cz bump --files-only
 echo "${branch} created!"
 echo
 read -p $'\e[31mWould you like to push to origin now?\e[0m: ' -n 1 -r


### PR DESCRIPTION
This removes the unnecessary step of tagging a local branch during the release process. Tagging should only be handled on GitHub, then `fetch --tags`ed to adhere to commitizen-tools' best practices when using upstream tools to bump tags.