### PR TITLE
chore(ci): removes node package files from commitizen bump

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -4,12 +4,6 @@
     "version": "3.0.2",
     "tag_format": "$major.$minor.$patch$prerelease",
     "version_type": "semver",
-    "version_files": [
-      "back/package.json",
-      "back/package-lock.json",
-      "front/package.json",
-      "front/package-lock.json"
-    ],
     "bump_message": "release $current_version \u2192 $new_version",
     "customize": {
       "info": "This is customized info",

--- a/_utils/_scripts/bump.sh
+++ b/_utils/_scripts/bump.sh
@@ -19,19 +19,25 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         exit 1
     fi
     exit 1
+else
+    branch=$(git branch --show-current)
+    [[ $branch != release* ]] && git checkout -b release/$ver
+    branch=$(git branch --show-current)
+    echo "${branch} created!"
 fi
-branch=$(git branch --show-current)
-[[ $branch != release* ]] && git checkout -b release/$ver
-branch=$(git branch --show-current)
-echo "${branch} created!"
 read -p $'\e[31mWould you like to bump the version now?\e[0m: ' -n 1 -r
 echo # newline
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     exit 1
+else
+    cdfront
+    npm version $ver -s
+    cdback
+    npm version $ver -s
+    cd $directory/../
+    cz bump --files-only
+    git status
 fi
-cd $directory/../
-cz bump --files-only
-git status
 read -p $'\e[31mWould you like to stage release changes?\e[0m: ' -n 1 -r
 echo # newline
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
@@ -43,14 +49,16 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     fi
     git restore .
     exit 1
+else
+    git add .
+    git commit -m "chore(release): prepare for ${ver}"
 fi
-git add .
-git commit -m "chore(release): prepare for ${ver}"
 echo
 read -p $'\e[31mWould you like to push to origin now?\e[0m: ' -n 1 -r
 echo # newline
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     exit 1
+else
+    git push --set-upstream origin $branch
+    printDgBnr "Congratulations! ${branch} is queuing up for deployment!"
 fi
-git push --set-upstream origin $branch
-printDgBnr "Congratulations! ${branch} is queuing up for deployment!"


### PR DESCRIPTION
prefer use of `npm version` to prevent accidental updating of dependency versions by commitizen's regex