### PR TITLE
Release/3.16.1

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -1,7 +1,7 @@
 {
   "commitizen": {
     "name": "cz_customize",
-    "version": "3.16.0",
+    "version": "3.16.1",
     "gpg_sign": true,
     "tag_format": "$major.$minor.$patch$prerelease",
     "version_type": "semver",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.16.1] - 2024-01-20
+
+### 🐛 Bug Fixes
+
+- ***(front)*** Reduce fetchpriority of animated images
+
+### 💚 Continuous Integration
+
+- ***(terraform)*** Ipv6 support for vpc and security groups (#1171)
+- ***(terraform)*** Upgrades to and requires Terraform 1.7.0 with hashicorp/aws 5.33.0 (#1176)
+
+### ⚙️  Miscellaneous Tasks
+
+- ***(back)*** Override vite in backend package.json (CVE-2024-23331)
+- ***(back)*** Updates BE deps for CVE-2024-23331
+- ***(back)*** Fix update script
+- ***(front)*** Updates FE dependencies for CVE-2024-23331
+- ***(front)*** Use h2 for CV titles
+
 ## [3.16.0] - 2024-01-17
 
 ### 💡 Features

--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cms.dgrebb.com",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cms.dgrebb.com",
-      "version": "3.16.0",
+      "version": "3.16.1",
       "license": "MIT",
       "dependencies": {
         "@strapi/plugin-i18n": "4.17.1",

--- a/back/package.json
+++ b/back/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cms.dgrebb.com",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "private": true,
   "description": "cms.dgrebb.com",
   "license": "MIT",

--- a/front/package.json
+++ b/front/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgrebb.com",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "private": true,
   "scripts": {
     "check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json",


### PR DESCRIPTION
## [3.16.1] - 2024-01-20

### 🐛 Bug Fixes

- ***(front)*** Reduce fetchpriority of animated images

### 💚 Continuous Integration

- ***(terraform)*** Ipv6 support for vpc and security groups (#1171)
- ***(terraform)*** Upgrades to and requires Terraform 1.7.0 with hashicorp/aws 5.33.0 (#1176)

### ⚙️  Miscellaneous Tasks

- ***(back)*** Override vite in backend package.json (CVE-2024-23331)
- ***(back)*** Updates BE deps for CVE-2024-23331
- ***(back)*** Fix update script
- ***(front)*** Updates FE dependencies for CVE-2024-23331
- ***(front)*** Use h2 for CV titles