### PR TITLE
chore(back): override vite in backend package.json (CVE-2024-23331)

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -15,6 +15,7 @@
     "strapi": "strapi"
   },
   "dependencies": {
+    "@strapi/plugin-color-picker": "^4.17.1",
     "@strapi/plugin-i18n": "4.17.1",
     "@strapi/plugin-sentry": "4.17.1",
     "@strapi/plugin-seo": "^1.9.8",
@@ -32,5 +33,11 @@
     "node": ">=16.0.0 <=20.x.x",
     "npm": ">=6.0.0"
   },
-  "strapi": {}
+  "overrides": {
+    "vite": "^4.5.2"
+  },
+  "strapi": {},
+  "devDependencies": {
+    "prop-types": "^15.8.1"
+  }
 }


### PR DESCRIPTION
Closes: CVE-2024-23331

## Describe your changes

Had to override vite for strapi.