### PR TITLE
fix(front): apply fallback for category page canonicals (#1147)

### DIFF
--- a/front/src/routes/posts/category/[...category]/+page.server.js
+++ b/front/src/routes/posts/category/[...category]/+page.server.js
@@ -64,7 +64,9 @@ export async function load({ params }) {
       categoryDescription !== null
         ? categoryDescription
         : `"Read what I have to say about ${name}"`,
-    canonicalURL: seo?.canonicalURL ? seo?.canonicalURL : `https://www.dgrebb.com/posts/category/${category}/`
+    canonicalURL: seo?.canonicalURL
+      ? seo?.canonicalURL
+      : `https://www.dgrebb.com/posts/category/${category}/`,
   };
 
   /**

--- a/front/src/routes/posts/category/[...category]/+page.server.js
+++ b/front/src/routes/posts/category/[...category]/+page.server.js
@@ -64,6 +64,7 @@ export async function load({ params }) {
       categoryDescription !== null
         ? categoryDescription
         : `"Read what I have to say about ${name}"`,
+    canonicalURL: seo?.canonicalURL ? seo?.canonicalURL : `https://www.dgrebb.com/posts/category/${category}/`
   };
 
   /**


### PR DESCRIPTION
Closes: #1147

## Describe your changes

Uses fallback for canonical URLs while category landing page content is written.

## Checklist before requesting a review

- [x] Code linting succeeds
- [x] Visual Regression is Passing
- [x] I have performed a self-review of my code
- [x] Do we need to implement analytics?
- [x] Have you tested with JavaScript off?
