### PR TITLE
fix(front): ❤️  add assistive text to hero background image (#1234)

### DIFF
--- a/front/src/lib/components/posts/Post.svelte
+++ b/front/src/lib/components/posts/Post.svelte
@@ -42,7 +42,8 @@
     heroMime,
     loaded,
     position,
-    heroThumb;
+    heroThumb,
+    heroAlt;
 
   /**
    * Sets the active link in the page navigation.
@@ -105,6 +106,7 @@
         {loaded}
         {position}
         {heroThumb}
+        {heroAlt}
         slot="header"
       />
       {#if (toc && toc.length) || (categories && categories.length) || (related && related.length)}

--- a/front/src/lib/components/posts/PostHero.svelte
+++ b/front/src/lib/components/posts/PostHero.svelte
@@ -9,6 +9,7 @@
    * @property {string} heroImage - URL of the hero image.
    * @property {string} heroMime - MIME type of the hero image.
    * @property {string} heroThumb - URL of the hero thumbnail.
+   * @property {string} heroAlt - Alt text for the hero image.
    * @property {boolean} loaded - Flag indicating whether the hero image is loaded.
    * @property {string} position - CSS background position for the images.
    */
@@ -27,6 +28,11 @@
    * @type {Props}
    */
   export let heroThumb;
+
+  /**
+   * @type {Props}
+   */
+  export let heroAlt;
 
   /**
    * @type {Props}
@@ -70,11 +76,15 @@
     <div
       class={`post-hero {loaded ? 'post-hero-loaded' : ''}`}
       style={`background-image: url('${heroThumb}'); background-position: ${position}`}
+      role="img"
+      aria-label={heroAlt ? heroAlt : null}
     />
     <noscript>
       <div
         class="post-hero noscript"
         style="background-image: url('{heroImage}'); background-position: {position};"
+        role="img"
+        aria-label={heroAlt}
       />
     </noscript>
   </div>

--- a/front/src/routes/post/[slug]/+page.svelte
+++ b/front/src/routes/post/[slug]/+page.svelte
@@ -24,6 +24,7 @@
     ? hero.formats.thumbnail.url
     : false;
   $: heroImage = hero?.url ? hero.url : false;
+  $: heroAlt = hero?.alternativeText ? hero.alternativeText : false;
   $: heroMime = hero?.mime;
   $: position = post.position || 'center center';
   $: ({ publishedAt, updatedAt } = post);
@@ -65,6 +66,7 @@
       {loaded}
       {position}
       {heroThumb}
+      {heroAlt}
     />
   </section>
 


### PR DESCRIPTION
## Describe your changes

Uses `alternativeText` from CMS to add `aria-label` text to PostHero background image.

## Issue ticket number and link

Closes: #1234

## Checklist before requesting a review

- [x] Code linting succeeds
- [x] Visual Regression is Passing
- [x] I have performed a self-review of my code
- [x] Do we need to implement analytics?
- [x] Have you tested with JavaScript off?
