### PR TITLE
fix(front): remove left/right padding on centered post images (#1238)

### DIFF
--- a/front/src/lib/styles/pages/post.css
+++ b/front/src/lib/styles/pages/post.css
@@ -376,7 +376,7 @@
     &--center {
       float: none;
       margin: auto;
-      padding: 0.5rem;
+      padding: 0.5rem 0;
     }
   }
   .footnotes {


### PR DESCRIPTION
## Describe your changes

Removes left/right padding from center-aligned post images.

## Issue ticket number and link

Closes: #1238

## Checklist before requesting a review

- [x] Code linting succeeds
- [x] Visual Regression is Passing
- [x] I have performed a self-review of my code
- [x] Do we need to implement analytics?
- [x] Have you tested with JavaScript off?
