### PR TITLE
Release/3.18.7

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -1,7 +1,7 @@
 {
   "commitizen": {
     "name": "cz_customize",
-    "version": "3.18.6",
+    "version": "3.18.7",
     "gpg_sign": true,
     "use_shortcuts": true,
     "tag_format": "$major.$minor.$patch$prerelease",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.18.7] - 2024-03-29
+
+### 🐛 Bug Fixes
+
+- ***(ci)*** Add playwright to dependencies and get version from namespace
+
+### ♻️  Refactor
+
+- ***(ci)*** Use pnpx to install playwright
+
+### ⚙️  Miscellaneous Tasks
+
+- ***(back)*** Address CVEs
+- ***(back)*** Upgrade to strapi@4.21.1
+- ***(back)*** Upgrade to strapi@4.20.5
+
 ## [3.18.6] - 2024-02-27
 
 ### ♻️  Refactor

--- a/back/package.json
+++ b/back/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cms.dgrebb.com",
-  "version": "3.18.6",
+  "version": "3.18.7",
   "private": true,
   "description": "cms.dgrebb.com",
   "license": "MIT",

--- a/front/package.json
+++ b/front/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgrebb.com",
-  "version": "3.18.6",
+  "version": "3.18.7",
   "private": true,
   "scripts": {
     "check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --compiler-warnings \"css-unused-selector:ignore\"",


### PR DESCRIPTION
## [3.18.7] - 2024-03-29

### 🐛 Bug Fixes

- ***(ci)*** Add playwright to dependencies and get version from namespace

### ♻️  Refactor

- ***(ci)*** Use pnpx to install playwright

### ⚙️  Miscellaneous Tasks

- ***(back)*** Address CVEs
- ***(back)*** Upgrade to strapi@4.21.1
- ***(back)*** Upgrade to strapi@4.20.5