### PR TITLE
ci(github): install `pnpm@9` in gh actions

### DIFF
--- a/.github/actions/install-cache-deps/action.yml
+++ b/.github/actions/install-cache-deps/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: Install pnpm
       shell: bash
-      run: npm install -g pnpm@8
+      run: npm install -g pnpm@9
 
     - name: Get pnpm store directory
       shell: bash

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
         specifier: ^3.8.6
         version: 3.8.6(postcss-load-config@3.1.4(postcss@8.4.41))(postcss@8.4.41)(svelte@4.2.19)
       svelte-highlight:
-        specifier: 7.6.1
-        version: 7.6.1(patch_hash=cykfzl6dsuxouqabdlczoov3yy)
+        specifier: 7.7.0
+        version: 7.7.0(patch_hash=cykfzl6dsuxouqabdlczoov3yy)
       svelte-meta-tags:
         specifier: ^3.1.3
         version: 3.1.3(svelte@4.2.19)(typescript@5.5.4)
@@ -1084,10 +1084,6 @@ packages:
     resolution: {integrity: sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==}
     engines: {node: '>=12.0.0'}
 
-  highlight.js@11.9.0:
-    resolution: {integrity: sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==}
-    engines: {node: '>=12.0.0'}
-
   html-minifier-terser@7.2.0:
     resolution: {integrity: sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==}
     engines: {node: ^14.13.1 || >=16.0.0}
@@ -1756,8 +1752,8 @@ packages:
       svelte:
         optional: true
 
-  svelte-highlight@7.6.1:
-    resolution: {integrity: sha512-YIpA6LBVpghQndBsbZQLl3ufEje179vQTtC7FH/utbEmUwYecIXsBq4mcwNkCeUuCrpcaF0DkrppWmMp/ZoPfA==}
+  svelte-highlight@7.7.0:
+    resolution: {integrity: sha512-umBiTz3fLbbNCA+wGlRhJOb54iC6ap8S/dxjauQ+g6a8oFGTOGQeOP2rJVoh/K1ssF7IjP4P0T3Yuiu+vtaG5Q==}
 
   svelte-hmr@0.16.0:
     resolution: {integrity: sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==}
@@ -2970,8 +2966,6 @@ snapshots:
 
   highlight.js@11.10.0: {}
 
-  highlight.js@11.9.0: {}
-
   html-minifier-terser@7.2.0:
     dependencies:
       camel-case: 4.1.2
@@ -3607,9 +3601,9 @@ snapshots:
     optionalDependencies:
       svelte: 4.2.19
 
-  svelte-highlight@7.6.1(patch_hash=cykfzl6dsuxouqabdlczoov3yy):
+  svelte-highlight@7.7.0(patch_hash=cykfzl6dsuxouqabdlczoov3yy):
     dependencies:
-      highlight.js: 11.9.0
+      highlight.js: 11.10.0
 
   svelte-hmr@0.16.0(svelte@4.2.19):
     dependencies:


### PR DESCRIPTION
## Describe your changes

`pnpm@9` in gh actions — one of the newer versions of pnpm removed version from its patch file naming, which breaks `<pnpm@9` CI/CD. the lockfiles are now incompatible if one has package patches.